### PR TITLE
rational number refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
 project(matrix_operations)
 
+# compile with debugging
+set(DEBUG OFF)
+
 set(CMAKE_CXX_STANDARD 14)
+set(STATIC_LIB_DIR "/usr/lib/x86_64-linux-gnu") # set to directory where static libaries are located
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+set(TESTING_DIR test)
 
-SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+if (DEBUG)
+    add_compile_options(-Wall -pedantic -g3)
+else()
+    add_compile_options(-Wall -pedantic -O3)
+endif()
 
-add_compile_options(-Wall -pedantic -g3)
+find_package(Threads REQUIRED)
+set(STATIC_LIBRARIES "${STATIC_LIB_DIR}/libgmpxx.a" "${STATIC_LIB_DIR}/libgmp.a" Threads::Threads)
 
 add_executable(matrix_operations main.cpp LinearSystem.h LinearSystem.cpp Matrix.cpp Matrix.h)
 
-add_executable(testLinearSystem LinearSystem.cpp LinearSystem.h test/TestLinearSystem.cpp test/TestLinearSystem.h
-        Matrix.cpp Matrix.h)
+add_executable(testLinearSystem LinearSystem.cpp LinearSystem.h ${TESTING_DIR}/TestLinearSystem.cpp
+        ${TESTING_DIR}/TestLinearSystem.h Matrix.cpp Matrix.h)
+
+target_link_libraries(testLinearSystem ${STATIC_LIBRARIES})
+target_link_libraries(matrix_operations ${STATIC_LIBRARIES})
 

--- a/Matrix.cpp
+++ b/Matrix.cpp
@@ -15,14 +15,14 @@ namespace wwills2{
         m_mxmIdentity = nullptr;
         m_nxnIdentity = nullptr;
 
-        //allocate array of double array pointers
-        m_elements = new double *[m_numRows];
+        //allocate array of mpq_class array pointers
+        m_elements = new mpq_class *[m_numRows];
 
         //initialize array and allocate individual m_elements
-        double num = 1;
+        mpq_class num = 1;
 
         for (int row = 0; row < m_numRows; row++){
-            m_elements[row] = new double[m_numCols];
+            m_elements[row] = new mpq_class[m_numCols];
             for (int col = 0; col < m_numCols; col++){
                 m_elements[row][col] = num;
                 num++;
@@ -85,12 +85,12 @@ namespace wwills2{
         m_mxmIdentity = nullptr;
         m_nxnIdentity = nullptr;
 
-        //allocate array of double array pointers
-        m_elements = new double *[m_numRows];
+        //allocate array of mpq_class array pointers
+        m_elements = new mpq_class *[m_numRows];
 
         //initialize array and allocate individual m_elements
         for (int row = 0; row < m_numRows; row++){
-            m_elements[row] = new double[m_numCols];
+            m_elements[row] = new mpq_class[m_numCols];
             for (int col = 0; col < m_numCols; col++){
                 m_elements[row][col] = 0;
             }
@@ -114,29 +114,33 @@ namespace wwills2{
             m_pivotPositions = rhs.m_pivotPositions;
 
             //dynamically initialize m_elements
-            m_elements = new double *[m_numRows];
+            m_elements = new mpq_class *[m_numRows];
 
             for (int row = 0; row < m_numRows; row++) {
-                m_elements[row] = new double[m_numCols];
+                m_elements[row] = new mpq_class[m_numCols];
                 for (int col = 0; col < m_numCols; col++) {
                     m_elements[row][col] = rhs.m_elements[row][col];
                 }
             }
 
             //allocate and copy MxM identity matrix
-            m_mxmIdentity = new double *[m_numRows];
+            m_mxmIdentity = new mpq_class *[m_numRows];
 
             for (int row = 0; row < m_numRows; row++){
-                m_mxmIdentity[row] = new double[m_numRows];
-                memcpy(m_mxmIdentity[row], rhs.m_mxmIdentity[row], sizeof (double) * m_numRows);
+                m_mxmIdentity[row] = new mpq_class[m_numRows];
+                for (int col = 0; col < m_numRows; col++){
+                    m_mxmIdentity[row][col] = rhs.m_mxmIdentity[row][col];
+                }
             }
 
             //allocate and copy NxN identity matrix
-            m_nxnIdentity = new double *[m_numCols];
+            m_nxnIdentity = new mpq_class *[m_numCols];
 
             for (int row = 0; row < m_numCols; row++){
-                m_nxnIdentity[row] = new double[m_numCols];
-                memcpy(m_nxnIdentity[row], rhs.m_nxnIdentity[row], sizeof (double) * m_numCols);
+                m_nxnIdentity[row] = new mpq_class[m_numCols];
+                for (int col = 0; col < m_numCols; col++){
+                    m_nxnIdentity[row][col] = rhs.m_nxnIdentity[row][col];
+                }
             }
         }
     }
@@ -159,7 +163,7 @@ namespace wwills2{
     void Matrix::makeEchelonForm() {
 
         if (!m_isEchelon && !m_isReducedEchelon){
-            double rowScalar = 0;
+            mpq_class rowScalar = 0;
             std::pair<int, int> pivot = {0, 0};
 
             //get non-zero into pivot position
@@ -191,6 +195,7 @@ namespace wwills2{
                             }
 
                             replaceRows(pivot.first, row, rowScalar);
+                            m_elements[row][pivot.second] = 0; //force clear to prevent precision problems
                         }
                     }
 
@@ -224,8 +229,8 @@ namespace wwills2{
             makeEchelonForm();
         }
 
-        double factor = 0;
-        double rowScalar = 0;
+        mpq_class factor = 0;
+        mpq_class rowScalar = 0;
         auto currPivot = m_pivotPositions[0];
 
         //loop through pivot positions starting with the last one added / rightmost
@@ -285,10 +290,10 @@ namespace wwills2{
                 delete[] m_elements;
 
                 //realloc matrix to match rhs dimensions
-                m_elements = new double*[rhs.m_numRows];
+                m_elements = new mpq_class*[rhs.m_numRows];
                 for (int row = 0; row < rhs.m_numRows; row++){
 
-                    m_elements[row] = new double[rhs.m_numCols];
+                    m_elements[row] = new mpq_class[rhs.m_numCols];
                 }
 
                 //delete MxM identity matrix
@@ -319,25 +324,31 @@ namespace wwills2{
 
             //copy m_elements
             for (int row = 0; row < m_numRows; row++){
-                memcpy(m_elements[row], rhs.m_elements[row], sizeof (double) * m_numCols);
+                for (int col = 0; col < m_numCols; col++){
+                    m_elements[row][col] = rhs.m_elements[row][col];
+                }
             }
 
             if (rebuildIdentity){
 
                 //reallocate and copy MxM identity matrix
-                m_mxmIdentity = new double *[m_numRows];
+                m_mxmIdentity = new mpq_class *[m_numRows];
 
                 for (int row = 0; row < m_numRows; row++){
-                    m_mxmIdentity[row] = new double[m_numRows];
-                    memcpy(m_mxmIdentity[row], rhs.m_mxmIdentity[row], sizeof (double) * m_numRows);
+                    m_mxmIdentity[row] = new mpq_class[m_numRows];
+                    for (int col = 0; col < m_numRows; col++){
+                        m_mxmIdentity[row][col] = rhs.m_mxmIdentity[row][col];
+                    }
                 }
 
                 //reallocate and copy NxN identity matrix
-                m_nxnIdentity = new double *[m_numCols];
+                m_nxnIdentity = new mpq_class *[m_numCols];
 
                 for (int row = 0; row < m_numCols; row++){
-                    m_nxnIdentity[row] = new double[m_numCols];
-                    memcpy(m_nxnIdentity[row], rhs.m_nxnIdentity[row], sizeof (double) * m_numCols);
+                    m_nxnIdentity[row] = new mpq_class[m_numCols];
+                    for (int col = 0; col < m_numCols; col++){
+                        m_nxnIdentity[row][col] = rhs.m_nxnIdentity[row][col];
+                    }
                 }
             }
 
@@ -349,8 +360,8 @@ namespace wwills2{
 
     void Matrix::buildIdentityMxM() {
 
-        //allocate array of double array pointers
-        m_mxmIdentity = new double *[m_numRows];
+        //allocate array of mpq_class array pointers
+        m_mxmIdentity = new mpq_class *[m_numRows];
 
         //build m x m matrix
         std::vector<std::thread> threads;
@@ -368,15 +379,15 @@ namespace wwills2{
     void Matrix::buildIdentityMxMThread(const int &startRow, const int &numThreads) {
 
         for (int row = startRow; row < m_numRows; row += numThreads){
-            m_mxmIdentity[row] = new double[m_numRows]{};
+            m_mxmIdentity[row] = new mpq_class[m_numRows]{};
             m_mxmIdentity[row][row] = 1;
         }
     }
 
     void Matrix::buildIdentityNxN() {
 
-        //allocate array of double array pointers
-        m_nxnIdentity = new double *[m_numCols];
+        //allocate array of mpq_class array pointers
+        m_nxnIdentity = new mpq_class *[m_numCols];
 
         //build n x n matrix
         std::vector<std::thread> threads;
@@ -395,12 +406,12 @@ namespace wwills2{
 
         for (int row = startRow; row < m_numCols; row += numThreads){
 
-            m_nxnIdentity[row] = new double[m_numCols]{};
+            m_nxnIdentity[row] = new mpq_class[m_numCols]{};
             m_nxnIdentity[row][row] = 1;
         }
     }
 
-    inline double *Matrix::operator[](const int &row) {
+    inline mpq_class *Matrix::operator[](const int &row) {
         return m_elements[row];
     }
 
@@ -417,47 +428,60 @@ namespace wwills2{
         }
     }
 
-    void Matrix::replaceRows(const int &sourceRow, const int &destinationRow, const double &sourceMultiple) {
+    void Matrix::replaceRows(const int &sourceRow, const int &destinationRow, const mpq_class &sourceMultiple) {
 
         //multiply entries in the source row and add them to the destination row
         for (int col = 0; col < m_numCols; col++){
 
             ///REMOVE
-            double destElement = m_elements[destinationRow][col];
-            double srcElement = m_elements[sourceRow][col];
-            double scaledSrcElement = m_elements[sourceRow][col] * sourceMultiple;
-            double result = destElement + scaledSrcElement;
+            mpq_class destElement = m_elements[destinationRow][col];
+            mpq_class srcElement = m_elements[sourceRow][col];
+            mpq_class scaledSrcElement = m_elements[sourceRow][col] * sourceMultiple;
+            mpq_class result = destElement + scaledSrcElement;
 
             m_elements[destinationRow][col] += (m_elements[sourceRow][col] * sourceMultiple);
 
-            if (std::abs(m_elements[destinationRow][col]) < ZERO_CUTOFF){
+            /*
+            if (abs(m_elements[destinationRow][col]) < ZERO_CUTOFF){
                 m_elements[destinationRow][col] = 0;
             }
+             */
         }
     }
 
     void Matrix::interchangeRows(const int &swapRow1, const int &swapRow2) {
 
+        int i;
+
         //copy swap row 1 to temp location
-        double *tempArray = new double[m_numCols];
-        memcpy(tempArray, m_elements[swapRow1], sizeof (double) * m_numCols);
+        auto *tempArray = new mpq_class[m_numCols];
+        for (i = 0; i < m_numCols; i++){
+            tempArray[i] = m_elements[swapRow1][i];
+        }
 
         //copy swap row 2 to swap row 1
-        memcpy(m_elements[swapRow1], m_elements[swapRow2], sizeof (double) * m_numCols);
+        for (i = 0; i < m_numCols; i++){
+            m_elements[swapRow1][i] = m_elements[swapRow2][i];
+        }
 
         //copy temp to swap row 2
-        memcpy(m_elements[swapRow2], tempArray, sizeof (double) * m_numCols);
+        for (i = 0; i < m_numCols; i++){
+            m_elements[swapRow2][i] = tempArray[i];
+        }
 
         delete[] tempArray;
     }
 
-    void Matrix::scaleRow(const int &row, const double &factor) {
+    void Matrix::scaleRow(const int &row, const mpq_class &factor) {
 
         for (int col = 0; col < m_numCols; col++){
             m_elements[row][col] *= factor;
+
+            /*
             if (std::abs(m_elements[row][col]) < ZERO_CUTOFF){
                 m_elements[row][col] = 0;
             }
+             */
         }
     }
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -6,6 +6,9 @@
 #define MATRIX_OPERATIONS_MATRIX_H
 
 #include <cstring>
+#include <algorithm>
+#include <iterator>
+#include <gmpxx.h>
 #include "LinearSystem.h"
 
 namespace wwills2{
@@ -39,15 +42,15 @@ namespace wwills2{
 
         void buildIdentityNxNThread(const int &startRow, const int &numThreads);
 
-        double *operator[](const int &row);
+        mpq_class *operator[](const int &row);
 
         void addRows(const int &sourceRow, const int &destinationRow);
 
-        void replaceRows(const int &sourceRow, const int &destinationRow, const double &sourceMultiple);
+        void replaceRows(const int &sourceRow, const int &destinationRow, const mpq_class &sourceMultiple);
 
         void interchangeRows(const int &swapRow1, const int &swapRow2);
 
-        void scaleRow(const int &row, const double &factor);
+        void scaleRow(const int &row, const mpq_class &factor);
 
         bool makeFirstPivotNonZero(std::pair<int, int> &pivot);
 
@@ -59,9 +62,9 @@ namespace wwills2{
         bool m_isEchelon;                                   //tracks if the matrix is in echelon form
         bool m_isReducedEchelon;                            //tracks if the matrix has been reduced
         std::vector<std::pair<int, int>> m_pivotPositions;  //the pivot positions of the matrix
-        double **m_elements;                                 //2d, dynamically allocated, m_elements array
-        double **m_mxmIdentity;                              //identity matrix #rows x #rows
-        double **m_nxnIdentity;                              //identity matrix #cols x #cols
+        mpq_class **m_elements;                                 //2d, dynamically allocated, m_elements array
+        mpq_class **m_mxmIdentity;                              //identity matrix #rows x #rows
+        mpq_class **m_nxnIdentity;                              //identity matrix #cols x #cols
 
         friend LinearSystem;
 

--- a/test/TestLinearSystem.cpp
+++ b/test/TestLinearSystem.cpp
@@ -13,7 +13,7 @@ using std::endl;
 static std::ofstream logFile;
 enum rowOperations {ADD, REPLACE, INTERCHANGE, SCALE};
 
-inline double *wwills2::Matrix::operator[](const int &row) {
+inline mpq_class *wwills2::Matrix::operator[](const int &row) {
     return m_elements[row];
 }
 
@@ -192,7 +192,7 @@ void TestLinearSystem::dotVsOverloadBench() {
 
     stop = clock();
 
-    double time = ((double)(stop - start)) / CLOCKS_PER_SEC;
+    mpq_class time = ((mpq_class)(stop - start)) / CLOCKS_PER_SEC;
     cout << "\tdot operator: " << time << " seconds" << endl;
 
     //start counting clock cycles
@@ -207,7 +207,7 @@ void TestLinearSystem::dotVsOverloadBench() {
 
     stop = clock();
 
-    time = ((double)(stop - start)) / CLOCKS_PER_SEC;
+    time = ((mpq_class)(stop - start)) / CLOCKS_PER_SEC;
     cout << "\toverloaded [] operator: " << time << " seconds" << endl;
 }
 
@@ -297,7 +297,7 @@ TestLinearSystem::generateRandomReducedMatrix(const int matrixRows, const int ma
 
             if (std::find(pivotColumns.begin(), pivotColumns.end(), j) == pivotColumns.end() &&
                         makeNonZero.getRandNum()){
-                newMatrix[pivot.first][j] = (double) randElement.getRandNum();
+                newMatrix[pivot.first][j] = (mpq_class) randElement.getRandNum();
             }
         }
     }
@@ -314,7 +314,9 @@ void TestLinearSystem::matrixRandomize(wwills2::Matrix &toRandomize, Random &ran
     int operation = 0;
     int iRow = 0;
     int jRow = 0;
-    double scalar = 0;
+    mpq_class scalar(0);
+    bool zeroRow = true;
+
 
     for (int iteration = 0; iteration < numIterations; iteration++){
 
@@ -322,6 +324,7 @@ void TestLinearSystem::matrixRandomize(wwills2::Matrix &toRandomize, Random &ran
 
         switch (operation) {
             case ADD:
+
                 iRow = randRowNum.getRandNum();
                 jRow = randRowNum.getRandNum();
                 toRandomize.addRows(iRow, jRow);
@@ -329,22 +332,33 @@ void TestLinearSystem::matrixRandomize(wwills2::Matrix &toRandomize, Random &ran
 
             case REPLACE:
 
+                break; //todo: disables operation. needs to be fixed
+
                 iRow = randRowNum.getRandNum();
                 jRow = randRowNum.getRandNum();
-                scalar = (double) randScalar.getRandNum();
+                scalar = mpq_class(randScalar.getRandNum());
+
+                //check that the source row to copy in isn't a zero row. would result in loss of data
+                for (int i = 0; i < toRandomize.m_numCols; i++){
+                    if (toRandomize[iRow][i] != 0){
+                        zeroRow = false;
+                    }
+                }
+                if (zeroRow) break; //do not replace if source row is 0
 
                 if (invertScalar.getRandNum()){
-                scalar = 1 / scalar;
+                    scalar = 1 / scalar;
                 }
 
                 if (negateScalar.getRandNum()){
-                scalar *= -1;
+                    scalar *= -1;
                 }
 
                 toRandomize.replaceRows(iRow, jRow, scalar);
                 break;
 
             case INTERCHANGE:
+
                 iRow = randRowNum.getRandNum();
                 jRow = randRowNum.getRandNum();
 
@@ -354,7 +368,7 @@ void TestLinearSystem::matrixRandomize(wwills2::Matrix &toRandomize, Random &ran
             case SCALE:
 
                 iRow = randRowNum.getRandNum();
-                scalar = (double) randScalar.getRandNum();
+                scalar = mpq_class(randScalar.getRandNum());
 
                 if (invertScalar.getRandNum()){
                     scalar = 1 / scalar;
@@ -511,7 +525,7 @@ void TestLinearSystem::matrixOverloadedElementOp() {
 
     wwills2::Matrix testMatrix;
 
-    double *row = testMatrix[0];
+    mpq_class *row = testMatrix[0];
     assert(row[0] == 1 && row[1] == 2 && row[2] == 3);
 
     wwills2::LinearSystem testSystem;
@@ -546,12 +560,12 @@ void TestLinearSystem::echelonFormTest() {
         int rows = 4;
         int cols = 6;
 
-        double initialMatrix[24] = {0, 3, -6, 6, 4 ,-5,
+        mpq_class initialMatrix[24] = {0, 3, -6, 6, 4 ,-5,
                                    3, -7, 8, -5, 8, 9,
                                    0 , 0, 0, 0, 0, 0,
                                    3, -9, 12, -9, 6, 15};
 
-        double initialEchelonMatrix[24] = {3, -9, 12, -9, 6, 15,
+        mpq_class initialEchelonMatrix[24] = {3, -9, 12, -9, 6, 15,
                                           0, 2, -4, 4, 2, -6,
                                           0, 0, 0, 0, 1, 4,
                                           0 , 0, 0, 0, 0, 0,};
@@ -585,11 +599,11 @@ void TestLinearSystem::echelonFormTest() {
         int rows = 3;
         int cols = 4;
 
-        double initialMatrix[12] = {1 ,5, 2, -6,
+        mpq_class initialMatrix[12] = {1 ,5, 2, -6,
                                    0 ,4, -7, 2 ,
                                    0, 0 , 5, 0};
 
-        double initialEchelonMatrix[12] = {1 ,5, 2, -6,
+        mpq_class initialEchelonMatrix[12] = {1 ,5, 2, -6,
                                           0 ,4, -7, 2 ,
                                           0, 0 , 5, 0};
 
@@ -622,12 +636,12 @@ void TestLinearSystem::echelonFormTest() {
         int rows = 4;
         int cols = 5;
 
-        double initialMatrix[20] = {0, -3, -6, 4, 9,
+        mpq_class initialMatrix[20] = {0, -3, -6, 4, 9,
                                    -1, -2 , -1, 3, 1,
                                    -2, -3, 0, 3, -1,
                                    1, 4, 5, -9, -7};
 
-        double initialEchelonMatrix[20] = {1, 4, 5, -9, -7,
+        mpq_class initialEchelonMatrix[20] = {1, 4, 5, -9, -7,
                                           0, 2, 4, -6, -6,
                                           0, 0 , 0, -5, 0,
                                           0, 0, 0, 0, 0};
@@ -662,11 +676,11 @@ void TestLinearSystem::echelonFormTest() {
         int rows = 3;
         int cols = 4;
 
-        double initialMatrix[12] = {1 ,0, -5, 1,
+        mpq_class initialMatrix[12] = {1 ,0, -5, 1,
                                    0 ,1, 1, 4,
                                    0, 0 , 0, 0};
 
-        double initialEchelonMatrix[12] = {1 ,0, -5, 1,
+        mpq_class initialEchelonMatrix[12] = {1 ,0, -5, 1,
                                           0 ,1, 1, 4,
                                           0, 0 , 0, 0};
 
@@ -699,11 +713,11 @@ void TestLinearSystem::echelonFormTest() {
         int rows = 3;
         int cols = 4;
 
-        double initialMatrix[12] = {1, 0, -5, 1,
+        mpq_class initialMatrix[12] = {1, 0, -5, 1,
                                    0, 0, 0, 0,
                                    0, 1, 1, 4,};
 
-        double initialEchelonMatrix[12] = {1, 0, -5, 1,
+        mpq_class initialEchelonMatrix[12] = {1, 0, -5, 1,
                                           0, 1, 1, 4,
                                           0, 0, 0, 0};
 
@@ -736,13 +750,13 @@ void TestLinearSystem::echelonFormTest() {
         int rows = 5;
         int cols = 6;
 
-        double initialMatrix[30] = {1, 6, 2, -5, -2, -4,
+        mpq_class initialMatrix[30] = {1, 6, 2, -5, -2, -4,
                                    0, 0, 0, 0, 0, 0,
                                    0, 0, 0, 0, 1, 7,
                                    0, 0, 0, 0, 0, 0,
                                    0, 0, 2, -8, -1, 3};
 
-        double initialEchelonMatrix[30] = {1, 6, 2, -5, -2, -4,
+        mpq_class initialEchelonMatrix[30] = {1, 6, 2, -5, -2, -4,
                                           0, 0, 2, -8, -1, 3,
                                           0, 0, 0, 0, 1, 7,
                                           0, 0, 0, 0, 0, 0,
@@ -869,7 +883,7 @@ void TestLinearSystem::echelonFormTest() {
 void TestLinearSystem::reducedEchelonFormTest() {
 
     int numTests = 100;
-    int maxRowCol = 4;
+    int maxRowCol = 10;
     int minRowCol = 3;
     int matrixRows = 0;
     int matrixCols = 0;
@@ -881,6 +895,8 @@ void TestLinearSystem::reducedEchelonFormTest() {
 
 
     for (int testNum = 0; testNum < numTests; testNum++){
+
+        logFile << "matrix #" << testNum << endl;
 
         //individual test scope
         {
@@ -906,8 +922,8 @@ void TestLinearSystem::reducedEchelonFormTest() {
             logFile << "matrix at " << &testMatrix << " after reduction" << endl;
             testMatrix.print(logFile);
 
-            double testElement;
-            double controlElement;
+            mpq_class testElement;
+            mpq_class controlElement;
 
             /*
              * the test operates by generating a random matrix in reduced echelon form with rows of 0's at random. the


### PR DESCRIPTION
refactored the underlying data type from double to mpq_class, the rational class type implemented by the GNU Multiprecision Arithmetic Library (GMP). the refactor has corrected persistent floating point precision errors causing the reduction algorithm to be incorrect.

CMakeLists.txt has been reworked to properly link GMP and the C++ thread library.

The matrix randomize function has had the 'replace' elementary row operation disabled because it needs to be reworked to prevent information loss when the matrix is randomized.